### PR TITLE
Added support for multisort (#378)

### DIFF
--- a/src/genomehubs-api/src/api-v2.yaml
+++ b/src/genomehubs-api/src/api-v2.yaml
@@ -794,7 +794,7 @@ components:
       style: form
     sortByParam:
       description: |
-        Field name to sort results by
+        Field name to sort results by.Multiple fields can be specified as a comma-separated list or array.
       examples:
         null:
           value:
@@ -805,14 +805,19 @@ components:
         assembly_level:
           value: assembly_level
           summary: Sort results by assembly level
+        multiple_fields:
+          value: assembly_level,chromosome_number
+          summary: Sort results by assembly level, then by chromosome number
       in: query
       name: sortBy
       required: false
       schema:
-        type: string
+        type: array
+        items:
+          type: string
     sortModeParam:
       description: |
-        Method to summarise multiple values for sorting fields with lists of values
+        Method to summarise multiple values for sorting fields with lists of values.Multiple methods can be specified as a comma-separated list or array.
       examples:
         null:
           value:
@@ -832,20 +837,25 @@ components:
         sum:
           value: sum
           summary: Use sum of values (numeric fields only)
+        multiple_modes:
+          value: max,min
+          summary: Use maximum value for the first field, minimum value for the second field
       in: query
       name: sortMode
       required: false
       schema:
-        enum:
-          - avg
-          - max
-          - median
-          - min
-          - sum
-        type: string
+        type: array
+        items:
+          type: string
+          enum:
+            - avg
+            - max
+            - median
+            - min
+            - sum
     sortOrderParam:
       description: |
-        Sort order to use when returning results.
+        Sort order(s) to use when returning results.Multiple orders can be specified as a comma-separated list or array.
 
         Only applicable when `sortBy` is defined.
       examples:
@@ -858,14 +868,19 @@ components:
         desc:
           value: desc
           summary: Sort values in descending order
+        multiple_orders:
+          value: asc,desc
+          summary: Sort first field in ascending order, second field in descending order
       in: query
       name: sortOrder
       required: false
       schema:
-        enum:
-          - asc
-          - desc
-        type: string
+        type: array
+        items:
+          type: string
+          enum:
+            - asc
+            - desc
     streamFileParam:
       description: |
         Stream a file instead of downloading

--- a/src/genomehubs-api/src/api/v2/queries/queryFragments/setSortOrder.js
+++ b/src/genomehubs-api/src/api/v2/queries/queryFragments/setSortOrder.js
@@ -99,6 +99,9 @@ export const setSortOrder = (sortBys, lookupTypes, lookupNames = () => {}) => {
   if (!sortBys) {
     return [];
   }
+  if (Array.isArray(sortBys) && sortBys.length > 0 && Array.isArray(sortBys[0])) {
+    sortBys = sortBys.flat();
+  }
   if (!Array.isArray(sortBys)) {
     sortBys = [sortBys];
   }

--- a/src/genomehubs-api/src/api/v2/reports/setSortBy.js
+++ b/src/genomehubs-api/src/api/v2/reports/setSortBy.js
@@ -1,15 +1,27 @@
 export const setSortBy = ({ sortBy, sortOrder, sortMode }) => {
-  if (sortBy) {
-    let sort = {};
-    sort.by = sortBy;
-    if (sortOrder) {
-      sort.order = sortOrder;
-    }
-    if (sortMode) {
-      sort.mode = sortMode;
-    }
-    sortBy = sort;
+  if(!sortBy){
+    return sortBy;
   }
+  if((typeof sortBy==="string" && sortBy.includes(","))|| Array.isArray(sortBy)){
+    const fields=Array.isArray(sortBy)?sortBy:sortBy.split(",");
+    const orders= sortOrder?(typeof sortOrder==="string"?sortOrder.split(","):sortOrder):[];
+    const modes= sortMode?(typeof sortMode==="string"?sortMode.split(","):sortMode):[];
+    return fields.map((field,index)=>{
+      const sort={by:field};
+      sort.order=orders[index]!== undefined?orders[index]:"asc";
+      sort.mode=modes[index]!== undefined?modes[index]:"max";
+      return sort;
+    })
+  }
+  let sort = {};
+  sort.by = sortBy;
+  if (sortOrder) {
+    sort.order = sortOrder;
+  }
+  if (sortMode) {
+    sort.mode = sortMode;
+  }
+  sortBy = sort;
   return sortBy;
 };
 

--- a/src/genomehubs-api/src/api/v2/reports/setSortBy.js
+++ b/src/genomehubs-api/src/api/v2/reports/setSortBy.js
@@ -4,12 +4,12 @@ export const setSortBy = ({ sortBy, sortOrder, sortMode }) => {
   }
   if((typeof sortBy==="string" && sortBy.includes(","))|| Array.isArray(sortBy)){
     const fields=Array.isArray(sortBy)?sortBy:sortBy.split(",");
-    const orders= sortOrder?(typeof sortOrder==="string"?sortOrder.split(","):sortOrder):[];
-    const modes= sortMode?(typeof sortMode==="string"?sortMode.split(","):sortMode):[];
+    const orders= parseValues(sortOrder);
+    const modes= parseValues(sortMode);
     return fields.map((field,index)=>{
       const sort={by:field};
-      sort.order=orders[index]!== undefined?orders[index]:"asc";
-      sort.mode=modes[index]!== undefined?modes[index]:"max";
+      sort.order=getValueWithFallback(orders, index, "asc");
+      sort.mode=getValueWithFallback(modes, index, "max")
       return sort;
     })
   }
@@ -24,5 +24,14 @@ export const setSortBy = ({ sortBy, sortOrder, sortMode }) => {
   sortBy = sort;
   return sortBy;
 };
+
+const parseValues = (value) => {  
+  if (!value) return [];  
+  return typeof value === "string" ? value.split(",") : value;  
+};  
+
+const getValueWithFallback = (value,index, fallback) => {
+  return value[index] !==undefined ? value[index] : (value.length > 0 ? value[value.length - 1] : fallback)
+}
 
 export default setSortBy;


### PR DESCRIPTION
This PR adds support for **multi-sort functionality** in the API.
### Changes Made
1. **`setSortBy.js`**:
   - Updated to handle arrays or comma-separated values for `sortBy`, `sortOrder`, and `sortMode`.
   - Returns an array of sort objects for multi-sort.

2. **`setSortOrder.js`**:
   - Updated to process multiple sort parameters and flatten nested arrays (if any).
   - Ensures compatibility with `addSortParameter`.

3. **`api-v2.yaml`**:
   - Updated the OpenAPI specification to reflect that `sortBy`, `sortOrder`, and `sortMode` can now accept arrays or comma-separated values.

## Summary by Sourcery

Adds support for multi-sort functionality to the API, allowing users to sort results by multiple fields.

Enhancements:
- Updates the API to handle arrays or comma-separated values for sortBy, sortOrder, and sortMode parameters.
- Updates setSortBy.js to return an array of sort objects for multi-sort.
- Updates setSortOrder.js to process multiple sort parameters and flatten nested arrays.