### PR TITLE
Add story to AggregationIcon.jsx

### DIFF
--- a/src/genomehubs-ui/src/client/views/components/AggregationIcon.jsx
+++ b/src/genomehubs-ui/src/client/views/components/AggregationIcon.jsx
@@ -2,7 +2,7 @@ import Grid from "@mui/material/Grid2";
 import React from "react";
 import Tooltip from "./Tooltip";
 import { compose } from "recompose";
-import withColors from "../hocs/withColors";
+import withColors from "#hocs/withColors";
 
 const AggregationIcon = ({ method, hasDescendants, statusColors = {} }) => {
   const colors = {

--- a/src/genomehubs-ui/src/client/views/components/AggregationIcon.stories.jsx
+++ b/src/genomehubs-ui/src/client/views/components/AggregationIcon.stories.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import AggregationIcon from "../components/AggregationIcon";
 import { Provider } from "react-redux";
-import store from "../reducers/color.store"; // Update this based on actual store path
+import store from "../reducers/color.store"; 
 
 export default {
   title: "Components/AggregationIcon",
@@ -21,9 +21,6 @@ export default {
     hasDescendants: {
       control: { type: "boolean" },
     },
-    statusColors: {
-      control: "object",
-    },
   },
 };
 
@@ -33,19 +30,22 @@ export const Direct = Template.bind({});
 Direct.args = {
   method: "direct",
   hasDescendants: false,
-  statusColors: { direct: "green", descendant: "orange", ancestor: "red" },
+};
+
+export const DirectWithDescendants = Template.bind({});
+DirectWithDescendants.args = {
+  method: "direct",
+  hasDescendants: true,
 };
 
 export const Descendant = Template.bind({});
 Descendant.args = {
   method: "descendant",
-  hasDescendants: true,
-  statusColors: { direct: "green", descendant: "orange", ancestor: "red" },
+  hasDescendants: false,
 };
 
 export const Ancestor = Template.bind({});
 Ancestor.args = {
   method: "ancestor",
   hasDescendants: false,
-  statusColors: { direct: "green", descendant: "orange", ancestor: "red" },
 };

--- a/src/genomehubs-ui/src/client/views/components/AggregationIcon.stories.jsx
+++ b/src/genomehubs-ui/src/client/views/components/AggregationIcon.stories.jsx
@@ -1,0 +1,51 @@
+import React from "react";
+import AggregationIcon from "../components/AggregationIcon";
+import { Provider } from "react-redux";
+import store from "../reducers/color.store"; // Update this based on actual store path
+
+export default {
+  title: "Components/AggregationIcon",
+  component: AggregationIcon,
+  decorators: [
+    (Story) => (
+      <Provider store={store}>
+        <Story />
+      </Provider>
+    ),
+  ],
+  argTypes: {
+    method: {
+      control: { type: "select" },
+      options: ["direct", "descendant", "ancestor"],
+    },
+    hasDescendants: {
+      control: { type: "boolean" },
+    },
+    statusColors: {
+      control: "object",
+    },
+  },
+};
+
+const Template = (args) => <AggregationIcon {...args} />;
+
+export const Direct = Template.bind({});
+Direct.args = {
+  method: "direct",
+  hasDescendants: false,
+  statusColors: { direct: "green", descendant: "orange", ancestor: "red" },
+};
+
+export const Descendant = Template.bind({});
+Descendant.args = {
+  method: "descendant",
+  hasDescendants: true,
+  statusColors: { direct: "green", descendant: "orange", ancestor: "red" },
+};
+
+export const Ancestor = Template.bind({});
+Ancestor.args = {
+  method: "ancestor",
+  hasDescendants: false,
+  statusColors: { direct: "green", descendant: "orange", ancestor: "red" },
+};

--- a/src/genomehubs-ui/src/client/views/components/AggregationIcon.stories.jsx
+++ b/src/genomehubs-ui/src/client/views/components/AggregationIcon.stories.jsx
@@ -4,7 +4,6 @@ import { Provider } from "react-redux";
 import store from "../reducers/color.store"; 
 
 export default {
-  title: "Components/AggregationIcon",
   component: AggregationIcon,
   decorators: [
     (Story) => (


### PR DESCRIPTION
# Add Storybook Story for `AggregationIcon` Component

## **Description**
This PR adds a Storybook story for the AggregationIcon.jsx component, allowing developers to visualize and test its behavior in an isolated environment. It is to contribute towards the ongoing effort to migrate UI components to Storybook for better maintainability and testing.

### **What is this PR?**
- This PR adds a **Storybook story** for the `AggregationIcon.jsx` component.
- The story provides an isolated environment to visualize and test the `AggregationIcon` component.

### **Why is this PR needed?**
- Helps developers easily preview how the `AggregationIcon` component looks and behaves.
- Enables quick UI testing without needing to run the entire application.
- Contributes to the ongoing effort to migrate UI components to **Storybook** for better component management.

---

## **Changes in this PR**
 **Created `AggregationIcon.stories.jsx` inside `src/genomehubs-ui/src/client/views/components/`**  
**Added multiple states/examples of `AggregationIcon` to showcase different UI variations.**  
**Ensured compatibility with the existing component structure and props.**

---

## **How has this PR been tested?**
-  Ran Storybook locally using `npm run storybook` and verified the `AggregationIcon` component renders correctly.

---

## **Is this a breaking change?**
 **No breaking changes.**  
This PR **only adds a Storybook story** and does not modify existing component functionality.

---

## **Checklist before merging**
- [x] The code has been tested locally.
- [x] The Storybook story displays the component correctly.
- [x] No existing functionality is modified.

## Summary by Sourcery

Tests:
- Adds a Storybook story for the AggregationIcon component.