### PR TITLE
added support for rank-based filtering,configurable phylopic size(#377)

### DIFF
--- a/src/genomehubs-ui/src/client/views/components/Report.jsx
+++ b/src/genomehubs-ui/src/client/views/components/Report.jsx
@@ -19,6 +19,8 @@ export const queryPropList = [
   "taxonomy",
   "includeEstimates",
   "treeStyle",
+  "phylopicRank",  
+  "phylopicSize",
 ];
 
 const Report = ({
@@ -111,6 +113,8 @@ const Report = ({
   reportProps.hideErrorBars = props.hideErrorBars;
   reportProps.hideAncestralBars = props.hideAncestralBars;
   reportProps.showPhylopics = props.showPhylopics;
+  reportProps.phylopicRank = props.phylopicRank;  
+  reportProps.phylopicSize = props.phylopicSize ? parseInt(props.phylopicSize) : undefined;
   reportProps.highlight = props.highlight;
   reportProps.colorPalette = props.colorPalette;
   reportProps.excludeAncestral = props.excludeAncestral;

--- a/src/genomehubs-ui/src/client/views/components/ReportEdit.jsx
+++ b/src/genomehubs-ui/src/client/views/components/ReportEdit.jsx
@@ -172,6 +172,8 @@ export const queryPropList = {
     "hideErrorBars",
     "hideAncestralBars",
     "showPhylopics",
+    { prop: "phylopicRank", label: "species" },  
+    { prop: "phylopicSize", label: "100" }, 
     "yOpts",
     "treeStyle",
     "treeThreshold",
@@ -522,6 +524,58 @@ export const ReportEdit = ({
           </Select>
         </FormControl>
       );
+      if(queryProp=="phylopicRank"){
+        let items=[
+          { value: "", label: "Auto (tip nodes)" },
+          { value: "subspecies", label: "Subspecies" },
+          { value: "species", label: "Species" },
+          { value: "genus", label: "Genus" },
+          { value: "family", label: "Family" },
+          { value: "order", label: "Order" },
+          { value: "class", label: "Class" },
+          {value:"subphylum", label:"Subphylum"},
+          { value: "phylum", label: "Phylum" }
+        ].map(({value, label}) => (
+            <MenuItem key={value} value={value}>
+              {label}
+            </MenuItem>
+        ))
+        input = (
+          <FormControl variant="standard" style={{ width: "95%" }}>
+            <InputLabel id="select-phylopic-rank-label">PhyloPic Rank</InputLabel>
+            <Select
+              variant="standard"
+              labelId="select-phylopic-rank-label"
+              id="select-phylopic-rank"
+              value={values["phylopicRank"] || ""}
+              style={{ width: "95%" }}
+              onChange={(e) => handleChange(e, "phylopicRank")}
+            >
+              {items}
+            </Select>
+            <FormHelperText>
+              Which taxonomic rank to display PhyloPics for (empty = all tip nodes)
+            </FormHelperText>
+          </FormControl>
+        );
+      }
+      if(queryProp=="phylopicSize"){
+        input = (
+          <TextField
+            variant="standard"
+            id={queryProp + Math.random()}
+            label="PhyloPic Size (pixels)"
+            type="number"
+            value={values[queryProp] || ""}
+            style={{ width: "95%" }}
+            onChange={(e) => handleChange(e, "phylopicSize")}
+            onBlur={(e) => handleChange(e, "phylopicSize")}
+            onKeyPress={handleKeyPress}
+            inputProps={{ min: 20, max: 400, step: 10 }}
+            helperText="Size in pixels (20-400, empty = default(100))"
+          />
+        );
+      }
     } else if (
       queryProp == "includeEstimates" ||
       queryProp == "stacked" ||

--- a/src/genomehubs-ui/src/client/views/components/ReportItem.jsx
+++ b/src/genomehubs-ui/src/client/views/components/ReportItem.jsx
@@ -104,6 +104,8 @@ const ReportItem = ({
   hideErrorBars,
   hideAncestralBars,
   showPhyloPics,
+  phylopicRank, 
+  phylopicSize,
   highlight,
   colorPalette,
   excludeMissing,
@@ -475,6 +477,8 @@ const ReportItem = ({
             hideErrorBars={hideErrorBars}
             hideAncestralBars={hideAncestralBars}
             showPhylopics={showPhyloPics}
+            phylopicRank={phylopicRank}
+            phylopicSize={phylopicSize}
             levels={levels}
             hidePreview={hideMessage}
             {...qs.parse(queryString)}

--- a/src/genomehubs-ui/src/client/views/components/ReportTree.jsx
+++ b/src/genomehubs-ui/src/client/views/components/ReportTree.jsx
@@ -28,6 +28,8 @@ const ReportTree = ({
   hideErrorBars,
   hideAncestralBars,
   showPhyloPics,
+  phylopicRank,
+  phylopicSize,
   minDim,
   setMinDim,
   basename,
@@ -191,6 +193,8 @@ const ReportTree = ({
         hideErrorBars={hideErrorBars}
         hideAncestralBars={hideAncestralBars}
         showPhylopics={showPhyloPics}
+        phylopicRank={phylopicRank}
+        phylopicSize={phylopicSize}
       />
     );
   } else {
@@ -210,6 +214,8 @@ const ReportTree = ({
         hideErrorBars={hideErrorBars}
         hideAncestralBars={hideAncestralBars}
         showPhylopics={showPhyloPics}
+        phylopicRank={phylopicRank}
+        phylopicSize={phylopicSize}
       />
     );
   }

--- a/src/genomehubs-ui/src/client/views/components/ReportTreePaths.jsx
+++ b/src/genomehubs-ui/src/client/views/components/ReportTreePaths.jsx
@@ -43,6 +43,8 @@ const ReportTreePaths = ({
   theme,
   cats: catArray,
   phylopicWidth,
+  phylopicSize,
+  phylopicRank,
   hideErrorBars,
 }) => {
   if (!lines || lines.length == 0) {
@@ -715,15 +717,16 @@ const ReportTreePaths = ({
                 }
               }
               if (segment.showPhylopic) {
+                const phylopicHeight=charHeight|| phylopicSize;
                 newPhyloPics.push(
                   <PhyloPics
                     key={segment.taxon_id}
                     taxonId={segment.taxon_id}
                     scientificName={segment.scientific_name}
-                    maxHeight={charHeight}
+                    maxHeight={phylopicHeight}
                     maxWidth={phylopicWidth}
                     x={maxWidth + dataWidth}
-                    y={segment.yStart - charHeight / 2}
+                    y={segment.yStart - phylopicHeight / 2}
                     fixedRatio={1}
                     showAncestral={false}
                     sourceColors={false}

--- a/src/genomehubs-ui/src/client/views/components/ReportTreePaths.jsx
+++ b/src/genomehubs-ui/src/client/views/components/ReportTreePaths.jsx
@@ -717,7 +717,7 @@ const ReportTreePaths = ({
                 }
               }
               if (segment.showPhylopic) {
-                const phylopicHeight=charHeight|| phylopicSize;
+                const phylopicHeight=phylopicSize||charHeight;
                 newPhyloPics.push(
                   <PhyloPics
                     key={segment.taxon_id}

--- a/src/genomehubs-ui/src/client/views/components/ReportTreeRings.jsx
+++ b/src/genomehubs-ui/src/client/views/components/ReportTreeRings.jsx
@@ -32,6 +32,8 @@ const ReportTreeRings = ({
   hideAncestralBars,
   cats,
   phylopics,
+  phylopicRank , 
+  phylopicSize,
 }) => {
   if (!arcs || arcs.length == 0) {
     return null;
@@ -315,13 +317,15 @@ const ReportTreeRings = ({
       continue;
     }
     let { x, y, angle, scientificName, width, height, arc } = opts;
+    const useHeight = phylopicSize || height;
+    const useWidth = phylopicSize || width;
     phylopicElements.push(
       <g key={taxonId}>
         <Phylopics
           taxonId={taxonId}
           scientificName={scientificName}
-          maxHeight={height}
-          maxWidth={width}
+          maxHeight={useHeight}
+          maxWidth={useWidth}
           fixedRatio={1}
           showAncestral={false}
           sourceColors={false}

--- a/src/genomehubs-ui/src/client/views/selectors/report.js
+++ b/src/genomehubs-ui/src/client/views/selectors/report.js
@@ -58,6 +58,8 @@ export const sortReportQuery = ({ queryString, options, ui = true }) => {
     hideErrorBars: { in: new Set(["tree"]), ui: true },
     hideAncestralBars: { in: new Set(["tree"]), ui: true },
     showPhylopics: { in: new Set(["tree"]), ui: true },
+    phylopicRank: { in: new Set(["tree"]), ui: true },
+    phylopicSize: { in: new Set(["tree"]), ui: true },
     highlight: { in: new Set(["table"]), ui: true },
     colorPalette: { not: new Set(["sources"]), ui: true },
     includeEstimates: true,
@@ -702,7 +704,7 @@ const processReport = (report, { searchTerm = {} }) => {
     if (!searchTerm) {
       searchTerm = qs.parse(window.location.search.replace(/^\?/, ""));
     }
-    let { hideErrorBars, hideAncestralBars, hideSourceColors, showPhylopics } =
+    let { hideErrorBars, hideAncestralBars, hideSourceColors, showPhylopics,phylopicRank,phylopicSize } =
       searchTerm;
     return {
       ...report,
@@ -722,6 +724,8 @@ const processReport = (report, { searchTerm = {} }) => {
             hideAncestralBars,
             hideSourceColors,
             showPhylopics,
+            phylopicRank,
+            phylopicSize:phylopicSize? parseInt(phylopicSize) : undefined,
           }),
         },
       },

--- a/src/genomehubs-ui/src/client/views/selectors/tree.js
+++ b/src/genomehubs-ui/src/client/views/selectors/tree.js
@@ -229,6 +229,8 @@ export const processTreeRings = ({
   hideAncestralBars,
   hideSourceColors,
   showPhylopics,
+  phylopicRank,
+  phylopicSize,
 }) => {
   if (!nodes) {
     return undefined;
@@ -402,18 +404,20 @@ export const processTreeRings = ({
     }
     if (
       node.taxon_rank != "assembly" &&
-      (!node.hasOwnProperty("children") ||
-        Object.keys(node.children).length == 0 ||
-        node.hasAssemblies ||
-        node.hasSamples) &&
       node.taxon_id &&
       showPhylopics &&
-      node.scientific_name != "parent"
+      node.scientific_name != "parent" &&
+      (
+      (phylopicRank && node.taxon_rank===phylopicRank)
+      || (!phylopicRank && (!node.hasOwnProperty("children") || 
+      Object.keys(node.children).length == 0))||
+      node.hasAssemblies ||
+      node.hasSamples)
     ) {
       let r = radius + dataWidth + phylopicWidth / 2;
 
       let width = (Math.PI * r * 2 * 0.9) / cMax;
-      let height = phylopicWidth * 0.9;
+      let height = phylopicSize || phylopicWidth * 0.9;
 
       phylopics[node.taxon_id] = {
         angle: (midAngle * 180) / Math.PI,
@@ -675,6 +679,8 @@ export const processTreePaths = ({
   pointSize,
   hideErrorBars,
   showPhylopics,
+  phylopicRank="species",
+  phylopicSize,
   hideAncestralBars,
   hideSourceColors,
 }) => {
@@ -707,7 +713,7 @@ export const processTreePaths = ({
   let phylopicWidth = 0;
 
   if (showPhylopics) {
-    phylopicWidth = charHeight * 1.5;
+    phylopicWidth = phylopicSize||charHeight * 1.5;
     targetWidth -= phylopicWidth;
   }
   let summary = (yQuery?.ySummaries || ["value"])[0];
@@ -897,7 +903,7 @@ export const processTreePaths = ({
       label = node.scientific_name;
       maxWidth = Math.max(maxWidth, stringLength(label) * pointSize * 0.8);
       maxTip = Math.max(maxTip, node.xEnd + 10);
-      showPhylopic = showPhylopics && node.scientific_name != "parent";
+      showPhylopic = showPhylopics && node.scientific_name != "parent" &&(phylopicRank?node.taxon_rank==phylopicRank:node.tip );
     } else if (node.scientific_name != "parent" && node.width > charLen * 5) {
       label = node.scientific_name;
       if (label.length * charLen - 2 > node.width) {
@@ -990,6 +996,8 @@ export const processTree = ({
   pointSize = 15,
   hideErrorBars,
   showPhylopics,
+  phylopicRank,
+  phylopicSize,
   hideAncestralBars,
   hideSourceColors,
 }) => {
@@ -1005,6 +1013,8 @@ export const processTree = ({
       hideAncestralBars,
       hideSourceColors,
       showPhylopics,
+      phylopicRank,
+      phylopicSize,
     });
   }
   return processTreePaths({
@@ -1018,5 +1028,7 @@ export const processTree = ({
     hideAncestralBars,
     hideSourceColors,
     showPhylopics,
+    phylopicRank,
+    phylopicSize,
   });
 };


### PR DESCRIPTION
These are the changes made:
- Supporting rank-based filtering
- Making PhyloPic sizes configurable
- Defaulting to tip nodes when no rank is specified

These changes should significantly improve the PhyloPic visualization by reducing clutter and allowing more control over which taxonomic levels display silhouettes

## Summary by Sourcery

Add support for configurable PhyloPic visualization by introducing rank-based filtering and customizable silhouette sizes

New Features:
- Implement rank-based filtering for PhyloPic silhouettes
- Add configurable PhyloPic size option

Enhancements:
- Provide more control over taxonomic levels for silhouette display
- Allow users to customize PhyloPic silhouette dimensions