### PR TITLE
Bugfix/support-null-in-aggs

### DIFF
--- a/src/genomehubs-api/src/api/v2/functions/parseCatOpts.js
+++ b/src/genomehubs-api/src/api/v2/functions/parseCatOpts.js
@@ -1,4 +1,42 @@
 export const parseCatOpts = ({ cat, query, lookupTypes }) => {
+  // splits cat and opts
+  // examples:
+  // input: cat = "c_value_method"
+  // output: cat = "c_value_method"
+  //         catOpts = ";;"
+  //
+  // input: cat = "c_value_method=flow cytometry"
+  // output: cat = "c_value_method"
+  //         catOpts = "flow cytometry;;"
+  //
+  // input: cat = "c_value_method[12]"
+  // output: cat = "c_value_method"
+  //         catOpts = ";;12"
+  //
+  // input: cat = "c_value_method[5+]"
+  // output: cat = "c_value_method"
+  //         catOpts = ";;5+"
+  //
+  // input: cat = "c_value_method[5+]=flow cytometry"
+  // output: cat = "c_value_method"
+  //         catOpts = "flow cytometry;;5+"
+  //
+  // input: cat = "c_value_method[5+]=flow cytometry,null"
+  // output: cat = "c_value_method"
+  //         catOpts = "flow cytometry,null;;5+"
+  //
+  // input: cat = "c_value_method[5+]=flow cytometry,null,feulgen densitometry"
+  // output: cat = "c_value_method"
+  //         catOpts = "flow cytometry,null,feulgen densitometry;;5+"
+  let [field, count, values] = (cat || "").split(/=*\[([\d\+]+)\]=*/);
+  let catMeta = lookupTypes(field);
+  let catOpts = `${typeof values === "undefined" ? "" : values};;${
+    typeof count === "undefined" ? "" : count
+  }`;
+  return { cat: field, catMeta, query, catOpts };
+};
+
+const oldParseCatOpts = ({ cat, query, lookupTypes }) => {
   let catOpts = ";;";
   let portions = (cat || "").split(/\s*[\[\]]\s*/);
   cat = portions[0];
@@ -52,7 +90,7 @@ export const parseCatOpts = ({ cat, query, lookupTypes }) => {
           queryArr = queryArr.concat([" AND ", portions[0], " <= ", max]);
         }
       } else {
-        queryArr = queryArr.concat([" AND ", portions[0]]);
+        // queryArr = queryArr.concat([" AND ", portions[0]]);
       }
       searchFields.push(portions[0]);
 
@@ -63,6 +101,8 @@ export const parseCatOpts = ({ cat, query, lookupTypes }) => {
     delete portions[1];
     cat = portions.join("");
   }
+  cat = "c_value_method";
+  catOpts = "flow cytometry,null,feulgen densitometry;;5+";
   return { cat, catMeta, query, catOpts };
 };
 

--- a/src/genomehubs-api/src/api/v2/reports/getBounds.js
+++ b/src/genomehubs-api/src/api/v2/reports/getBounds.js
@@ -212,7 +212,8 @@ export const getBounds = async ({
   let domain;
   try {
     aggs = res.aggs.aggregations[term] || res.aggs.aggregations[catTerm];
-  } catch {
+  } catch (err) {
+    console.log(res);
     return;
   }
 

--- a/src/genomehubs-api/src/api/v2/reports/getBounds.js
+++ b/src/genomehubs-api/src/api/v2/reports/getBounds.js
@@ -213,7 +213,7 @@ export const getBounds = async ({
   try {
     aggs = res.aggs.aggregations[term] || res.aggs.aggregations[catTerm];
   } catch (err) {
-    console.log(res);
+    // console.log(res);
     return;
   }
 

--- a/src/genomehubs-api/src/api/v2/reports/histogram.js
+++ b/src/genomehubs-api/src/api/v2/reports/histogram.js
@@ -373,29 +373,36 @@ const getHistogram = async ({
           ) {
             continue;
           }
-          let y = result.result.fields[yField][ySumm];
-          if (
-            yValueType == "keyword" &&
-            ySumm == "value" &&
-            !yKeys.has(y.toLowerCase())
-          ) {
-            continue;
+          let ys = result.result.fields[yField][ySumm];
+          if (!Array.isArray(ys)) {
+            ys = [ys];
           }
-          if (valueType == "date") {
-            x = Date.parse(x);
+          for (let y of ys) {
+            if (
+              yValueType == "keyword" &&
+              ySumm == "value" &&
+              !yKeys.has(y.toLowerCase())
+            ) {
+              continue;
+            }
+            if (valueType == "date") {
+              x = Date.parse(x);
+            }
+            if (yValueType == "date") {
+              y = Date.parse(y);
+            }
+            pointData[cat].push({
+              ...(result.result.scientific_name && {
+                scientific_name: result.result.scientific_name,
+              }),
+              ...(result.result.taxon_id && {
+                taxonId: result.result.taxon_id,
+              }),
+              x,
+              y,
+              cat,
+            });
           }
-          if (yValueType == "date") {
-            y = Date.parse(y);
-          }
-          pointData[cat].push({
-            ...(result.result.scientific_name && {
-              scientific_name: result.result.scientific_name,
-            }),
-            ...(result.result.taxon_id && { taxonId: result.result.taxon_id }),
-            x,
-            y,
-            cat,
-          });
         }
       }
     }

--- a/src/genomehubs-api/src/api/v2/reports/histogram.js
+++ b/src/genomehubs-api/src/api/v2/reports/histogram.js
@@ -645,7 +645,7 @@ const getHistogram = async ({
       yNullIndex,
       totalCount,
     });
-  } else if (catNullIndex > -1) {
+  } else if (nullIndex > -1 || catNullIndex > -1) {
     allCatValues = handleNulls2d({
       allYValues: allCatValues,
       allValues,
@@ -654,11 +654,10 @@ const getHistogram = async ({
       yNullIndex: catNullIndex,
       totalCount,
     });
-    // console.log({ allCatValues });
-    // console.log(bounds.cats);
     bounds.cats.forEach((obj, i) => {
-      byCat[obj.key] = allCatValues[i];
-      obj.doc_count = allCatValues[i].reduce((a, b) => a + b, 0);
+      let values = allCatValues.map((arr) => arr[i]);
+      byCat[obj.key] = values;
+      obj.doc_count = values.reduce((a, b) => a + b, 0);
     });
   }
 

--- a/src/genomehubs-api/src/api/v2/reports/histogram.js
+++ b/src/genomehubs-api/src/api/v2/reports/histogram.js
@@ -166,6 +166,7 @@ const getHistogram = async ({
 
   let { nullFields } = params;
 
+  // need result count for each value!
   if (nullFields && nullFields.length > 0) {
     let excludeMissing = params.excludeMissing.filter(
       (field) => !nullFields.includes(field)
@@ -275,6 +276,9 @@ const getHistogram = async ({
   }
 
   let hist = getHistAggResults(res.aggs.aggregations[field], bounds.stats);
+  console.log(JSON.stringify(res.aggs.aggregations, null, 2));
+
+  // need a count for each value
 
   if (!hist) {
     return;
@@ -760,7 +764,10 @@ export const histogram = async ({
       fields: yFields,
       summaries: ySummaries,
       result,
-      exclusions,
+      exclusions: {
+        ...exclusions,
+        missing: ["bioproject"],
+      },
       taxonomy,
       apiParams,
       opts: yOpts,

--- a/src/genomehubs-api/src/api/v2/reports/queryParams.js
+++ b/src/genomehubs-api/src/api/v2/reports/queryParams.js
@@ -46,8 +46,9 @@ export const queryParams = async ({
         }
         if (fieldMeta) {
           field = fieldMeta.name;
-
-          params.excludeMissing.push(field);
+          if (!nullFields.includes(field)) {
+            params.excludeMissing.push(field);
+          }
           fields.push(field);
           if (summary != "collate") {
             summaries.push(summary);

--- a/src/genomehubs-api/src/api/v2/reports/queryParams.js
+++ b/src/genomehubs-api/src/api/v2/reports/queryParams.js
@@ -17,6 +17,7 @@ export const queryParams = async ({
   };
   let fields = [];
   let summaries = [];
+  let nullFields = [];
   if (params.query) {
     if (
       (result == "taxon" || result == "assembly" || result == "sample") &&
@@ -30,7 +31,11 @@ export const queryParams = async ({
 
     term.split(/\s+(?:and|AND)\s+/).forEach((subterm) => {
       if (!subterm.match("tax_")) {
-        let field = subterm.replace(/[^\w_\(\)-].+$/, "").toLowerCase();
+        let [field, value] = subterm.split(/(?:=|!=|<=|>=|<|>)/);
+        field = field.replace(/[^\w_\(\)-].+$/, "").toLowerCase();
+        if (value && value.split(/\s*,\s*/).includes("null")) {
+          nullFields.push(field);
+        }
         let fieldMeta = lookupTypes(field);
         let summary = fieldMeta ? fieldMeta.return_type || "value" : "value";
         if (field.match(/\(/)) {
@@ -41,6 +46,7 @@ export const queryParams = async ({
         }
         if (fieldMeta) {
           field = fieldMeta.name;
+
           params.excludeMissing.push(field);
           fields.push(field);
           if (summary != "collate") {
@@ -71,6 +77,7 @@ export const queryParams = async ({
   params.excludeAncestral = [...new Set(params.excludeAncestral)];
   params.excludeDirect = [...new Set(params.excludeDirect)];
   params.excludeDescendant = [...new Set(params.excludeDescendant)];
+  params.nullFields = [...new Set(nullFields)];
 
   return { params, fields, summaries };
 };

--- a/src/genomehubs-api/src/api/v2/reports/setAggs.js
+++ b/src/genomehubs-api/src/api/v2/reports/setAggs.js
@@ -68,25 +68,6 @@ const attributeTerms = ({ cat, terms, size, yHistograms }) => {
           },
         },
       },
-      missing_key71: {
-        filter: {
-          bool: {
-            must_not: {
-              term: { "attributes.key": attribute },
-            },
-          },
-        },
-        aggs: {
-          by_value: {
-            filters,
-            ...(yHistograms && {
-              aggs: {
-                yHistograms,
-              },
-            }),
-          },
-        },
-      },
     },
   };
 };
@@ -137,23 +118,6 @@ const attributeCategory = ({ cat, cats, field, histogram, other }) => {
                   },
                 },
               },
-            },
-          },
-        },
-      },
-      missing_key114: {
-        filter: {
-          bool: {
-            must_not: {
-              term: { "attributes.key": cat },
-            },
-          },
-        },
-        aggs: {
-          by_value: {
-            filters,
-            aggs: {
-              histogram,
             },
           },
         },
@@ -492,25 +456,7 @@ export const setAggs = async ({
             terms,
             categoryHistograms,
             tree,
-            // yHistograms,
-          },
-        },
-        [`${field}_null`]: {
-          filter: {
-            bool: {
-              must_not: {
-                term: { "attributes.key": field },
-              },
-            },
-          },
-          aggs: {
-            histogram,
-            stats,
-            geo,
-            keywords,
-            terms,
-            categoryHistograms,
-            tree,
+            yHistograms,
           },
         },
       },

--- a/src/genomehubs-api/src/api/v2/reports/setAggs.js
+++ b/src/genomehubs-api/src/api/v2/reports/setAggs.js
@@ -398,7 +398,7 @@ export const setAggs = async ({
         field,
         summary,
         histogram,
-        other: bounds.showOther,
+        other: bounds.stats.showOther,
       });
     } else {
       categoryHistograms = lineageCategory({
@@ -407,7 +407,7 @@ export const setAggs = async ({
         field,
         summary,
         histogram,
-        other: bounds.showOther,
+        other: bounds.stats.showOther,
       });
     }
   }
@@ -459,6 +459,12 @@ export const setAggs = async ({
             yHistograms,
           },
         },
+        ...(yHistograms && {
+          yHistograms,
+        }),
+        ...(categoryHistograms && {
+          categoryHistograms,
+        }),
       },
     },
   };

--- a/src/genomehubs-api/src/api/v2/reports/setAggs.js
+++ b/src/genomehubs-api/src/api/v2/reports/setAggs.js
@@ -68,6 +68,25 @@ const attributeTerms = ({ cat, terms, size, yHistograms }) => {
           },
         },
       },
+      missing_key71: {
+        filter: {
+          bool: {
+            must_not: {
+              term: { "attributes.key": attribute },
+            },
+          },
+        },
+        aggs: {
+          by_value: {
+            filters,
+            ...(yHistograms && {
+              aggs: {
+                yHistograms,
+              },
+            }),
+          },
+        },
+      },
     },
   };
 };
@@ -118,6 +137,23 @@ const attributeCategory = ({ cat, cats, field, histogram, other }) => {
                   },
                 },
               },
+            },
+          },
+        },
+      },
+      missing_key114: {
+        filter: {
+          bool: {
+            must_not: {
+              term: { "attributes.key": cat },
+            },
+          },
+        },
+        aggs: {
+          by_value: {
+            filters,
+            aggs: {
+              histogram,
             },
           },
         },
@@ -457,6 +493,24 @@ export const setAggs = async ({
             categoryHistograms,
             tree,
             // yHistograms,
+          },
+        },
+        [`${field}_null`]: {
+          filter: {
+            bool: {
+              must_not: {
+                term: { "attributes.key": field },
+              },
+            },
+          },
+          aggs: {
+            histogram,
+            stats,
+            geo,
+            keywords,
+            terms,
+            categoryHistograms,
+            tree,
           },
         },
       },


### PR DESCRIPTION
Adds support for null values in reports to fix #120

## Summary by Sourcery

Add support for handling null values in histogram aggregations and reports

New Features:
- Add capability to include null values in histogram reports
- Implement flexible null value handling in query parameters

Bug Fixes:
- Fix handling of null values in histogram aggregations to correctly account for missing data points

Enhancements:
- Improve data processing to support null values in categorical and numeric fields
- Enhance histogram data aggregation to handle missing or null values more robustly