### PR TITLE
Fix badge positioning in result table for multi-digit values (#366)

### DIFF
--- a/src/genomehubs-ui/src/client/views/components/ResultTable.jsx
+++ b/src/genomehubs-ui/src/client/views/components/ResultTable.jsx
@@ -73,8 +73,9 @@ const StyledTableRow = withStyles((theme) => ({
 
 const StyledBadge = withStyles((theme) => ({
   badge: {
-    right: "50%",
-    top: 6,
+    right: "30% !important",
+    top: "10px !important",
+    transform: "scale(1) translate(calc(50% + 4px), -50%) !important",
     fontSize: "0.8em",
     border: "2px solid white",
     // padding: "0px 4px",
@@ -586,7 +587,7 @@ const formatCellValue = ({
   ) {
     let badgeContent = `+${field.length - entries.length}`;
     value = (
-      <span style={{ whiteSpace: "nowrap", marginRight: "0.75em" }}>
+      <span style={{ whiteSpace: "nowrap" }}>
         {value}
         <StyledBadge badgeContent={badgeContent} color={"default"} max={100000}>
           <span style={{ color: "rgba(0,0,0,0" }}>{badgeContent}</span>

--- a/src/genomehubs-ui/src/client/views/components/ResultTable.jsx
+++ b/src/genomehubs-ui/src/client/views/components/ResultTable.jsx
@@ -585,8 +585,11 @@ const formatCellValue = ({
     field.length > entries.length
   ) {
     let badgeContent = `+${field.length - entries.length}`;
+    let badgeLength = (badgeContent.length + 1) * 8;
     value = (
-      <div style={{ paddingRight: "80px", display: "inline-block" }}>
+      <div
+        style={{ paddingRight: `${badgeLength}px`, display: "inline-block" }}
+      >
         <StyledBadge badgeContent={badgeContent} max={100000}>
           <span style={{ display: "inline-block", position: "relative" }}>
             {value}

--- a/src/genomehubs-ui/src/client/views/components/ResultTable.jsx
+++ b/src/genomehubs-ui/src/client/views/components/ResultTable.jsx
@@ -71,18 +71,17 @@ const StyledTableRow = withStyles((theme) => ({
   },
 }))(TableRow);
 
-const StyledBadge = withStyles((theme) => ({
-  badge: {
-    right: "30% !important",
-    top: "10px !important",
-    transform: "scale(1) translate(calc(50% + 4px), -50%) !important",
-    fontSize: "0.8em",
+const StyledBadge = styled(Badge)(() => ({
+  "& .MuiBadge-badge": {
+    backgroundColor: "#333",
+    color: "#fff",
+    top: 0,
+    right: 0,
+    borderRadius: "10px",
     border: "2px solid white",
-    // padding: "0px 4px",
-    color: "white",
-    backgroundColor: "rgba(0,0,0,0.26)",
+    transform: "translate(98%, -50%)",
   },
-}))(Badge);
+}));
 
 export const useStyles = makeStyles((theme) => ({
   root: {
@@ -587,12 +586,13 @@ const formatCellValue = ({
   ) {
     let badgeContent = `+${field.length - entries.length}`;
     value = (
-      <span style={{ whiteSpace: "nowrap" }}>
-        {value}
-        <StyledBadge badgeContent={badgeContent} color={"default"} max={100000}>
-          <span style={{ color: "rgba(0,0,0,0" }}>{badgeContent}</span>
+      <div style={{ paddingRight: "80px", display: "inline-block" }}>
+        <StyledBadge badgeContent={badgeContent} max={100000}>
+          <span style={{ display: "inline-block", position: "relative" }}>
+            {value}
+          </span>
         </StyledBadge>
-      </span>
+      </div>
     );
   }
   return value;


### PR DESCRIPTION
### Problem
In the result table, the badge indicating the number of additional values was aligned correctly for single-digit numbers, but as the count increased to double or triple digits, the badge drifted further away from its associated value.

### Solution
Adjusted the styling logic to ensure consistent spacing and alignment between the value and badge, regardless of the number of digits.

### Related Issue
Closes #366

![image](https://github.com/user-attachments/assets/cdec1d1e-60de-43ac-ade1-f799cc103285)

## Summary by Sourcery

Fix badge positioning and styling in the result table to ensure consistent alignment across different digit counts

Bug Fixes:
- Corrected badge positioning for multi-digit values in the result table, preventing misalignment as the count of additional values increases

Enhancements:
- Updated badge styling to maintain consistent spacing and visual positioning regardless of the number of digits