### PR TITLE
feat(api): add endpoint to fetch and return valid taxonomic ranks (#160)

### DIFF
--- a/src/genomehubs-api/src/api-v2.yaml
+++ b/src/genomehubs-api/src/api-v2.yaml
@@ -1661,6 +1661,10 @@ paths:
       operationId: getTaxonomicRanks
       tags:
         - Metadata
+      parameters:
+        - $ref: "#/components/parameters/resultParam"
+        - $ref: "#/components/parameters/releaseParam"
+        - $ref: "#/components/parameters/indentParam"
       responses:
         "200":
           description: successful operation

--- a/src/genomehubs-api/src/api-v2.yaml
+++ b/src/genomehubs-api/src/api-v2.yaml
@@ -1663,6 +1663,7 @@ paths:
         - Metadata
       parameters:
         - $ref: "#/components/parameters/resultParam"
+        - $ref: "#/components/parameters/taxonomyParam"
         - $ref: "#/components/parameters/releaseParam"
         - $ref: "#/components/parameters/indentParam"
       responses:
@@ -1671,7 +1672,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TaxonomicRanks"
+                anyOf:
+                  - $ref: "#/components/schemas/Status"
+                    status: null
+                  - $ref: "#/components/schemas/TaxonomicRanks"
+                    results: null
         "400":
           description: Invalid request
       x-eov-operation-handler: api/v2/routes/taxonomicRanks

--- a/src/genomehubs-api/src/api-v2.yaml
+++ b/src/genomehubs-api/src/api-v2.yaml
@@ -1217,6 +1217,10 @@ components:
       items:
         type: string
       type: array
+    TaxonomicRanks:
+      items:
+        type: string
+      type: array
 info:
   contact:
     email: goat@genomehubs.org
@@ -1650,6 +1654,24 @@ paths:
       tags:
         - Metadata
       x-eov-operation-handler: api/v2/routes/taxonomies
+  /taxonomicRanks:
+    get:
+      summary: List of valid taxonomic ranks
+      description: Returns a list of valid taxonomic ranks such as domain, kingdom, phylum, etc.
+      operationId: getTaxonomicRanks
+      tags:
+        - Metadata
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TaxonomicRanks"
+        "400":
+          description: Invalid request
+      x-eov-operation-handler: api/v2/routes/taxonomicRanks
+
 servers:
   - url: http://localhost:3000/api/v2
 tags:

--- a/src/genomehubs-api/src/api/v2/functions/fetchTaxonomicRanks.js
+++ b/src/genomehubs-api/src/api/v2/functions/fetchTaxonomicRanks.js
@@ -1,15 +1,36 @@
-export const fetchTaxonomicRanks = async () => {
-  const ranks = [
-    "superkingdom",
-    "kingdom",
-    "phylum",
-    "class",
-    "order",
-    "family",
-    "genus",
-    "species",
-    "subspecies",
-  ];
+import { client } from "./connection.js";
 
-  return ranks;
+export const fetchTaxonomicRanks = async () => {
+  try {
+    const result = await client.search({
+      index: "taxonomy--ncbi--goat--2021.10.15",
+      body: {
+        size: 0,
+        query: {
+          bool: {
+            must_not: {
+              term: { taxon_rank: "no rank" },
+            },
+          },
+        },
+        aggs: {
+          unique_ranks: {
+            terms: {
+              field: "taxon_rank",
+              size: 100,
+            },
+          },
+        },
+      },
+    });
+
+    const ranks = result.body.aggregations.unique_ranks.buckets.map(
+      (bucket) => bucket.key
+    );
+
+    return ranks;
+  } catch (error) {
+    console.error("Error fetching taxonomic ranks:", error);
+    throw new Error("Failed to fetch taxonomic ranks");
+  }
 };

--- a/src/genomehubs-api/src/api/v2/functions/fetchTaxonomicRanks.js
+++ b/src/genomehubs-api/src/api/v2/functions/fetchTaxonomicRanks.js
@@ -2,16 +2,16 @@ import { client } from "./connection.js";
 import { config } from "./config.js";
 import { indexName } from "./indexName.js";
 
-export const fetchTaxonomicRanks = async () => {
+export const fetchTaxonomicRanks = async ({ result: resultParam, release }) => {
   try {
     const index = indexName({
-      result: "sample",
+      result: resultParam,
       taxonomy: config.taxonomy,
       hub: config.hub,
-      release: config.release,
+      release: release,
     });
 
-    const result = await client.search({
+    const esResult = await client.search({
       index,
       body: {
         size: 0,
@@ -33,7 +33,7 @@ export const fetchTaxonomicRanks = async () => {
       },
     });
 
-    const ranks = result.body.aggregations.unique_ranks.buckets.map(
+    const ranks = esResult.body.aggregations.unique_ranks.buckets.map(
       (bucket) => bucket.key
     );
 

--- a/src/genomehubs-api/src/api/v2/functions/fetchTaxonomicRanks.js
+++ b/src/genomehubs-api/src/api/v2/functions/fetchTaxonomicRanks.js
@@ -1,9 +1,18 @@
 import { client } from "./connection.js";
+import { config } from "./config.js";
+import { indexName } from "./indexName.js";
 
 export const fetchTaxonomicRanks = async () => {
   try {
+    const index = indexName({
+      result: "sample",
+      taxonomy: config.taxonomy,
+      hub: config.hub,
+      release: config.release,
+    });
+
     const result = await client.search({
-      index: "taxonomy--ncbi--goat--2021.10.15",
+      index,
       body: {
         size: 0,
         query: {

--- a/src/genomehubs-api/src/api/v2/functions/fetchTaxonomicRanks.js
+++ b/src/genomehubs-api/src/api/v2/functions/fetchTaxonomicRanks.js
@@ -31,8 +31,8 @@ export const fetchTaxonomicRanks = async ({ req }) => {
         },
       },
     });
-
-    const ranks = esResult?.body?.aggregations?.unique_ranks?.buckets.map(
+    const aggregations = esResult?.body?.aggregations || esResult?.aggregations;
+    const ranks = aggregations?.unique_ranks?.buckets.map(
       (bucket) => bucket.key
     );
     return {

--- a/src/genomehubs-api/src/api/v2/functions/fetchTaxonomicRanks.js
+++ b/src/genomehubs-api/src/api/v2/functions/fetchTaxonomicRanks.js
@@ -1,0 +1,15 @@
+export const fetchTaxonomicRanks = async () => {
+  const ranks = [
+    "superkingdom",
+    "kingdom",
+    "phylum",
+    "class",
+    "order",
+    "family",
+    "genus",
+    "species",
+    "subspecies",
+  ];
+
+  return ranks;
+};

--- a/src/genomehubs-api/src/api/v2/routes/taxonomicRanks.js
+++ b/src/genomehubs-api/src/api/v2/routes/taxonomicRanks.js
@@ -4,8 +4,7 @@ import { fetchTaxonomicRanks } from "../functions/fetchTaxonomicRanks.js";
 
 export const getTaxonomicRanks = async (req, res) => {
   try {
-    let response = [];
-    const taxonomicRanks = await fetchTaxonomicRanks();
+    const taxonomicRanks = await fetchTaxonomicRanks(req.query);
     return res.status(200).send(formatJson(taxonomicRanks, req.query.indent));
   } catch (error) {
     logError({

--- a/src/genomehubs-api/src/api/v2/routes/taxonomicRanks.js
+++ b/src/genomehubs-api/src/api/v2/routes/taxonomicRanks.js
@@ -1,15 +1,30 @@
 import { formatJson } from "../functions/formatJson.js";
-import { logError } from "../functions/logger.js";
 import { fetchTaxonomicRanks } from "../functions/fetchTaxonomicRanks.js";
 
 export const getTaxonomicRanks = async (req, res) => {
-  try {
-    const taxonomicRanks = await fetchTaxonomicRanks(req.query);
-    return res.status(200).send(formatJson(taxonomicRanks, req.query.indent));
-  } catch (error) {
-    logError({
-      req,
-      message: error.message || "Failed to fetch taxonomic ranks",
-    });
+  let status = {};
+  let ranks = [];
+  let took = 0;
+
+  const start = Date.now();
+  status = { success: true };
+
+  const taxonomicRanksResponse = await fetchTaxonomicRanks({ req });
+
+  if (!taxonomicRanksResponse.success) {
+    status = {
+      success: false,
+      error: taxonomicRanksResponse.error || "Internal Server error",
+    };
+    ranks = [];
+  } else {
+    ranks = taxonomicRanksResponse.ranks || [];
   }
+
+  took = Date.now() - start;
+
+  const response = { status, ranks, took };
+  return res
+    .status(status.success ? 200 : 500)
+    .send(formatJson(response, req.query.indent));
 };

--- a/src/genomehubs-api/src/api/v2/routes/taxonomicRanks.js
+++ b/src/genomehubs-api/src/api/v2/routes/taxonomicRanks.js
@@ -1,0 +1,16 @@
+import { formatJson } from "../functions/formatJson.js";
+import { logError } from "../functions/logger.js";
+import { fetchTaxonomicRanks } from "../functions/fetchTaxonomicRanks.js";
+
+export const getTaxonomicRanks = async (req, res) => {
+  try {
+    let response = [];
+    const taxonomicRanks = await fetchTaxonomicRanks();
+    return res.status(200).send(formatJson(taxonomicRanks, req.query.indent));
+  } catch (error) {
+    logError({
+      req,
+      message: error.message || "Failed to fetch taxonomic ranks",
+    });
+  }
+};


### PR DESCRIPTION

@rjchallis: Could you please confirm if this is the expected approach, or should I make any modifications?
Closes #160 

![image](https://github.com/user-attachments/assets/565ba9d3-cdf6-449f-9bcf-e0416d346fa5)

## Summary by Sourcery

Add a new API endpoint to retrieve a list of valid taxonomic ranks

New Features:
- Create a new `/taxonomicRanks` GET endpoint to return a list of standard taxonomic ranks

Enhancements:
- Implement a function to fetch a predefined list of taxonomic ranks