### PR TITLE
Update list of archive releases

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.10.13
+current_version = 2.10.14
 commit = True
 tag = True
 tag_name = {new_version}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.10.14
+current_version = 2.10.15
 commit = True
 tag = True
 tag_name = {new_version}

--- a/.github/workflows/package-genomehubs-archive.yml
+++ b/.github/workflows/package-genomehubs-archive.yml
@@ -3,32 +3,47 @@ name: package-genomehubs-archive
 on: workflow_dispatch
 
 env:
-  ARCHIVE_VERSION: 2022.11.16
+  ARCHIVE_VERSION: 2025.04.21
 
 jobs:
-  package-goat-ui-archive:
+  package-api-archive:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{github.ref}}
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: "18"
       - run: npm install -g pkg
       - run: |
-          git clone -b main --single-branch https://github.com/genomehubs/goat-ui
+          ./package-api.sh
+          mv ./dist/genomehubs-api ./dist/genomehubs-api-linux || exit 0
+      - uses: actions/upload-artifact@v4
+        with:
+          name: genomehubs-api
+          path: ./dist/*
+
+  package-goat-ui-archive:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+      - run: npm install -g pkg
+      - run: |
+          git clone https://github.com/genomehubs/goat-ui
           mv goat-ui/static/* src/genomehubs-ui/src/client/static/
           mv goat-ui/files/favicon/* src/genomehubs-ui/src/client/favicon/
           mv goat-ui/files/components/* src/genomehubs-ui/src/client/views/components/
           mv goat-ui/files/html/index.html src/genomehubs-ui/src/client/index.html
-          cd goat-ui
-          echo "GH_COMMIT_HASH=$(git log -n 1 --pretty=format:'%H')" >> $GITHUB_ENV
-          cd -
-          rm -r goat-ui
-      - run: |
-          GH_BASENAME=$ARCHIVE_VERSION ./package-ui.sh
-          mv ./dist/genomehubs-ui-linux-x64 ./dist/genomehubs-ui-linux || exit 0
+          rm -rf goat-ui
+      - run: ./package-ui.sh
+        env:
+          GH_API_URL: "https://goat.genomehubs.org/api/${{ env.ARCHIVE_VERSION }}"
+          GH_ARCHIVE: "latest 2024.09.14 2024.03.01 2023.10.16 2023.05.18 2023.02.20 2022.11.16"
+          GH_BASENAME: ${{ env.ARCHIVE_VERSION }}
+          GH_SITENAME: GoaT
+          GH_SUGGESTED_TERM: Canidae
       - uses: actions/upload-artifact@v4
         with:
           name: goat-ui
@@ -39,7 +54,7 @@ jobs:
     needs: package-goat-ui-archive
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{github.ref}}
       - uses: actions/download-artifact@v4
@@ -65,4 +80,35 @@ jobs:
           context: src/docker/goat
           push: true
           tags: genomehubs/goat:${{ env.ARCHIVE_VERSION }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  build-and-push-api-archive:
+    runs-on: ubuntu-latest
+    needs: package-api-archive
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: genomehubs-api
+          path: ./dist
+      - run: |
+          mv dist/genomehubs-api-linux src/docker/api/
+          rm -rf dist/*
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: genomehubs/genomehubs-api
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: src/docker/api
+          push: true
+          tags: genomehubs/genomehubs-api:${{ env.ARCHIVE_VERSION }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/package-genomehubs.yml
+++ b/.github/workflows/package-genomehubs.yml
@@ -1,6 +1,6 @@
 name: package-genomehubs
 env:
-  VERSION: 2.10.14
+  VERSION: 2.10.15
 
 on:
   push:

--- a/.github/workflows/package-genomehubs.yml
+++ b/.github/workflows/package-genomehubs.yml
@@ -1,6 +1,6 @@
 name: package-genomehubs
 env:
-  VERSION: 2.10.13
+  VERSION: 2.10.14
 
 on:
   push:

--- a/.github/workflows/package-genomehubs.yml
+++ b/.github/workflows/package-genomehubs.yml
@@ -146,7 +146,7 @@ jobs:
       - run: ./package-ui.sh
         env:
           GH_API_URL: "https://goat.genomehubs.org/api/v2"
-          GH_ARCHIVE: "latest 2024.09.14 2024.03.01 2023.10.16 2023.05.18 2023.02.20 2022.11.16"
+          GH_ARCHIVE: "latest 2025.04.21 2024.09.14 2024.03.01 2023.10.16 2023.05.18 2023.02.20 2022.11.16"
           GH_BASENAME: ""
           GH_SITENAME: GoaT
           GH_SUGGESTED_TERM: Canidae

--- a/README.rst
+++ b/README.rst
@@ -24,9 +24,9 @@ GenomeHubs
     :alt: Conda platforms
     :target: https://anaconda.org/tolkit/genomehubs
 
-.. |commits-since| image:: https://img.shields.io/github/commits-since/genomehubs/genomehubs/2.10.14.svg
+.. |commits-since| image:: https://img.shields.io/github/commits-since/genomehubs/genomehubs/2.10.15.svg
     :alt: Commits since latest release
-    :target: https://github.com/genomehubs/genomehubs/compare/2.10.14...main
+    :target: https://github.com/genomehubs/genomehubs/compare/2.10.15...main
 
 .. |license| image:: https://anaconda.org/tolkit/genomehubs/badges/license.svg
     :alt: MIT License

--- a/README.rst
+++ b/README.rst
@@ -24,9 +24,9 @@ GenomeHubs
     :alt: Conda platforms
     :target: https://anaconda.org/tolkit/genomehubs
 
-.. |commits-since| image:: https://img.shields.io/github/commits-since/genomehubs/genomehubs/2.10.13.svg
+.. |commits-since| image:: https://img.shields.io/github/commits-since/genomehubs/genomehubs/2.10.14.svg
     :alt: Commits since latest release
-    :target: https://github.com/genomehubs/genomehubs/compare/2.10.13...main
+    :target: https://github.com/genomehubs/genomehubs/compare/2.10.14...main
 
 .. |license| image:: https://anaconda.org/tolkit/genomehubs/badges/license.svg
     :alt: MIT License

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "genomehubs" %}
-{% set version = "2.10.13" %}
+{% set version = "2.10.14" %}
 
 package:
   name: {{ name }}

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "genomehubs" %}
-{% set version = "2.10.14" %}
+{% set version = "2.10.15" %}
 
 package:
   name: {{ name }}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ try:
     version = release = get_distribution("genomehubs").version
 except Exception:
     traceback.print_exc()
-    version = release = "2.10.13"
+    version = release = "2.10.14"
 
 pygments_style = "trac"
 templates_path = ["."]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ try:
     version = release = get_distribution("genomehubs").version
 except Exception:
     traceback.print_exc()
-    version = release = "2.10.14"
+    version = release = "2.10.15"
 
 pygments_style = "trac"
 templates_path = ["."]

--- a/scripts/conda_build.sh
+++ b/scripts/conda_build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-VERSION=2.10.14
+VERSION=2.10.15
 
 case $(uname | tr '[:upper:]' '[:lower:]') in
   linux*)

--- a/scripts/conda_build.sh
+++ b/scripts/conda_build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-VERSION=2.10.13
+VERSION=2.10.14
 
 case $(uname | tr '[:upper:]' '[:lower:]') in
   linux*)

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def read(*names, **kwargs):
 
 setup(
     name="genomehubs",  # Required
-    version="2.10.13",
+    version="2.10.14",
     description="GenomeHubs",  # Optional
     long_description="%s\n%s"
     % (

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def read(*names, **kwargs):
 
 setup(
     name="genomehubs",  # Required
-    version="2.10.14",
+    version="2.10.15",
     description="GenomeHubs",  # Optional
     long_description="%s\n%s"
     % (

--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 LABEL maintainer="contact@genomehubs.org"
 LABEL license="MIT"
-ARG VERSION=2.10.14
+ARG VERSION=2.10.15
 LABEL version=$VERSION
 ENV CONTAINER_VERSION=$VERSION
 

--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 LABEL maintainer="contact@genomehubs.org"
 LABEL license="MIT"
-ARG VERSION=2.10.13
+ARG VERSION=2.10.14
 LABEL version=$VERSION
 ENV CONTAINER_VERSION=$VERSION
 

--- a/src/docker/api/Dockerfile
+++ b/src/docker/api/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.15
 LABEL maintainer="contact@genomehubs.org"
 LABEL license="MIT"
-ARG VERSION=2.10.14
+ARG VERSION=2.10.15
 LABEL version=$VERSION
 
 ENV CONTAINER_VERSION=$VERSION

--- a/src/docker/api/Dockerfile
+++ b/src/docker/api/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.15
 LABEL maintainer="contact@genomehubs.org"
 LABEL license="MIT"
-ARG VERSION=2.10.13
+ARG VERSION=2.10.14
 LABEL version=$VERSION
 
 ENV CONTAINER_VERSION=$VERSION

--- a/src/docker/goat/Dockerfile
+++ b/src/docker/goat/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.15
 LABEL maintainer="contact@genomehubs.org"
 LABEL license="MIT"
-ARG VERSION=genomehubs/genomehubs-ui:2.10.14
+ARG VERSION=genomehubs/genomehubs-ui:2.10.15
 LABEL version=$VERSION
 
 ENV CONTAINER_VERSION=$VERSION

--- a/src/docker/goat/Dockerfile
+++ b/src/docker/goat/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.15
 LABEL maintainer="contact@genomehubs.org"
 LABEL license="MIT"
-ARG VERSION=genomehubs/genomehubs-ui:2.10.13
+ARG VERSION=genomehubs/genomehubs-ui:2.10.14
 LABEL version=$VERSION
 
 ENV CONTAINER_VERSION=$VERSION

--- a/src/docker/ui/Dockerfile
+++ b/src/docker/ui/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.15
 LABEL maintainer="contact@genomehubs.org"
 LABEL license="MIT"
-ARG VERSION=2.10.14
+ARG VERSION=2.10.15
 LABEL version=$VERSION
 
 ENV CONTAINER_VERSION=$VERSION

--- a/src/docker/ui/Dockerfile
+++ b/src/docker/ui/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.15
 LABEL maintainer="contact@genomehubs.org"
 LABEL license="MIT"
-ARG VERSION=2.10.13
+ARG VERSION=2.10.14
 LABEL version=$VERSION
 
 ENV CONTAINER_VERSION=$VERSION

--- a/src/genomehubs-api/package-lock.json
+++ b/src/genomehubs-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "genomehubs-api",
-  "version": "2.10.14",
+  "version": "2.10.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "genomehubs-api",
-      "version": "2.10.14",
+      "version": "2.10.15",
       "license": "MIT",
       "dependencies": {
         "@elastic/elasticsearch": "^8.15.0",

--- a/src/genomehubs-api/package-lock.json
+++ b/src/genomehubs-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "genomehubs-api",
-  "version": "2.10.13",
+  "version": "2.10.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "genomehubs-api",
-      "version": "2.10.13",
+      "version": "2.10.14",
       "license": "MIT",
       "dependencies": {
         "@elastic/elasticsearch": "^8.15.0",

--- a/src/genomehubs-api/package.json
+++ b/src/genomehubs-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genomehubs-api",
-  "version": "2.10.13",
+  "version": "2.10.14",
   "description": "GenomeHubs API",
   "scripts": {
     "api": "node --max-old-space-size=12288 src/app.js",

--- a/src/genomehubs-api/package.json
+++ b/src/genomehubs-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genomehubs-api",
-  "version": "2.10.14",
+  "version": "2.10.15",
   "description": "GenomeHubs API",
   "scripts": {
     "api": "node --max-old-space-size=12288 src/app.js",

--- a/src/genomehubs-api/src/api-v2.yaml
+++ b/src/genomehubs-api/src/api-v2.yaml
@@ -1236,6 +1236,10 @@ components:
       items:
         type: string
       type: array
+    TaxonomicRanks:
+      items:
+        type: string
+      type: array
 info:
   contact:
     email: goat@genomehubs.org
@@ -1670,6 +1674,33 @@ paths:
       tags:
         - Metadata
       x-eov-operation-handler: api/v2/routes/taxonomies
+  /taxonomicRanks:
+    get:
+      summary: List of valid taxonomic ranks
+      description: Returns a list of valid taxonomic ranks such as domain, kingdom, phylum, etc.
+      operationId: getTaxonomicRanks
+      tags:
+        - Metadata
+      parameters:
+        - $ref: "#/components/parameters/resultParam"
+        - $ref: "#/components/parameters/taxonomyParam"
+        - $ref: "#/components/parameters/releaseParam"
+        - $ref: "#/components/parameters/indentParam"
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - $ref: "#/components/schemas/Status"
+                    status: null
+                  - $ref: "#/components/schemas/TaxonomicRanks"
+                    results: null
+        "400":
+          description: Invalid request
+      x-eov-operation-handler: api/v2/routes/taxonomicRanks
+
 servers:
   - url: http://localhost:3000/api/v2
 tags:

--- a/src/genomehubs-api/src/api/v2/functions/fetchTaxonomicRanks.js
+++ b/src/genomehubs-api/src/api/v2/functions/fetchTaxonomicRanks.js
@@ -1,0 +1,55 @@
+import { client } from "./connection.js";
+import { indexName } from "./indexName.js";
+import { logError } from "./logger.js";
+
+export const fetchTaxonomicRanks = async ({ req }) => {
+  try {
+    const index = indexName({
+      result: req.query.result,
+      taxonomy: req.query.taxonomy,
+      release: req.query.release,
+    });
+
+    const esResult = await client.search({
+      index,
+      body: {
+        size: 0,
+        query: {
+          bool: {
+            must_not: {
+              term: { taxon_rank: "no rank" },
+            },
+          },
+        },
+        aggs: {
+          unique_ranks: {
+            terms: {
+              field: "taxon_rank",
+              size: 100,
+            },
+          },
+        },
+      },
+    });
+    const aggregations = esResult?.body?.aggregations || esResult?.aggregations;
+    const ranks = aggregations?.unique_ranks?.buckets.map(
+      (bucket) => bucket.key
+    );
+    return {
+      success: true,
+      error: null,
+      ranks,
+    };
+  } catch (error) {
+    logError({
+      req,
+      message: error.message,
+    });
+
+    return {
+      success: false,
+      error: error.message || "Failed to fetch taxonomic ranks",
+      ranks: [],
+    };
+  }
+};

--- a/src/genomehubs-api/src/api/v2/functions/setRanks.js
+++ b/src/genomehubs-api/src/api/v2/functions/setRanks.js
@@ -3,7 +3,7 @@ export const setRanks = (rank) => {
     return rank.split(/[,;\s]+/);
   } else {
     return [
-      "superkingdom",
+      "domain",
       "kingdom",
       "phylum",
       "class",

--- a/src/genomehubs-api/src/api/v2/queries/queryFragments/setSortOrder.js
+++ b/src/genomehubs-api/src/api/v2/queries/queryFragments/setSortOrder.js
@@ -2,7 +2,7 @@ import setSortBy from "../../reports/setSortBy.js";
 import { subsets } from "../../functions/subsets.js";
 
 const ranks = {
-  superkingdom: true,
+  domain: true,
   kingdom: true,
   phylum: true,
   class: true,

--- a/src/genomehubs-api/src/api/v2/reports/histogram.js
+++ b/src/genomehubs-api/src/api/v2/reports/histogram.js
@@ -201,10 +201,10 @@ const getNestedHistogramData = ({
   let yNullIndex = -1;
   let fullYBuckets;
   let fullYValues;
-  if (yHistograms && yField) {
-    if (yHistograms.by_attribute[yField]) {
+  if (yHistograms.by_attribute && yField) {
+    if (yHistograms.by_attribute?.[yField]) {
       yNullCount = totalCount - yHistograms.by_attribute[yField].doc_count;
-    } else {
+    } else if (yHistograms.by_attribute?.by_cat) {
       yNullCount = totalCount - yHistograms.by_attribute.by_cat.doc_count;
     }
     ({ yBuckets: fullYBuckets, yValues: fullYValues } = getYValues({
@@ -1016,7 +1016,7 @@ export const histogram = async ({
       apiParams,
       opts: catOpts,
     });
-    if (nullCatBounds.stats.cats) {
+    if (nullCatBounds?.stats?.cats) {
       bounds.cats = nullCatBounds.stats.cats;
       bounds.showOther =
         nullCatBounds.stats.showOther || Boolean(catString.match(/\bnull\b/));

--- a/src/genomehubs-api/src/api/v2/routes/report.js
+++ b/src/genomehubs-api/src/api/v2/routes/report.js
@@ -33,7 +33,7 @@ const plurals = (singular) => {
     class: "classes",
     phylum: "phyla",
     kingdom: "kingdoms",
-    superkingdom: "superkingdoms",
+    domain: "domains",
   };
   return ranks[singular.toLowerCase()] || singular;
 };

--- a/src/genomehubs-api/src/api/v2/routes/taxonomicRanks.js
+++ b/src/genomehubs-api/src/api/v2/routes/taxonomicRanks.js
@@ -1,0 +1,30 @@
+import { formatJson } from "../functions/formatJson.js";
+import { fetchTaxonomicRanks } from "../functions/fetchTaxonomicRanks.js";
+
+export const getTaxonomicRanks = async (req, res) => {
+  let status = {};
+  let ranks = [];
+  let took = 0;
+
+  const start = Date.now();
+  status = { success: true };
+
+  const taxonomicRanksResponse = await fetchTaxonomicRanks({ req });
+
+  if (!taxonomicRanksResponse.success) {
+    status = {
+      success: false,
+      error: taxonomicRanksResponse.error || "Internal Server error",
+    };
+    ranks = [];
+  } else {
+    ranks = taxonomicRanksResponse.ranks || [];
+  }
+
+  took = Date.now() - start;
+
+  const response = { status, ranks, took };
+  return res
+    .status(status.success ? 200 : 500)
+    .send(formatJson(response, req.query.indent));
+};

--- a/src/genomehubs-ui/package-lock.json
+++ b/src/genomehubs-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "genomehubs-ui",
-  "version": "2.10.13",
+  "version": "2.10.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "genomehubs-ui",
-      "version": "2.10.13",
+      "version": "2.10.14",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "^11.13.3",

--- a/src/genomehubs-ui/package-lock.json
+++ b/src/genomehubs-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "genomehubs-ui",
-  "version": "2.10.14",
+  "version": "2.10.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "genomehubs-ui",
-      "version": "2.10.14",
+      "version": "2.10.15",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "^11.13.3",

--- a/src/genomehubs-ui/package.json
+++ b/src/genomehubs-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genomehubs-ui",
-  "version": "2.10.14",
+  "version": "2.10.15",
   "description": "Frontend for GenomeHubs",
   "main": "index.js",
   "scripts": {

--- a/src/genomehubs-ui/package.json
+++ b/src/genomehubs-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genomehubs-ui",
-  "version": "2.10.13",
+  "version": "2.10.14",
   "description": "Frontend for GenomeHubs",
   "main": "index.js",
   "scripts": {

--- a/src/genomehubs-ui/src/client/views/components/LineagePanel.jsx
+++ b/src/genomehubs-ui/src/client/views/components/LineagePanel.jsx
@@ -39,8 +39,8 @@ export const LineageList = ({
       setPreferSearchTerm(false);
       navigate(
         `?recordId=${taxon}&result=taxon&taxonomy=${taxonomy}#${encodeURIComponent(
-          `${taxon}[${name}]`
-        )}`
+          `${taxon}[${name}]`,
+        )}`,
       );
       setLookupTerm(name);
     }
@@ -57,7 +57,7 @@ export const LineageList = ({
     "class",
     "phylum",
     "kingdom",
-    "superkingdom",
+    "domain",
   ]);
 
   if (lineage && lineage.lineage) {
@@ -65,7 +65,7 @@ export const LineageList = ({
       let rank = ancestor.taxon_rank == "clade" ? "" : ancestor.taxon_rank;
       let css = classnames(
         rankStyle,
-        fullRanks.has(ancestor.taxon_rank) && boldStyle
+        fullRanks.has(ancestor.taxon_rank) && boldStyle,
       );
       let rankDiv = <div className={css}>{rank}</div>;
 
@@ -85,7 +85,7 @@ export const LineageList = ({
             {rankDiv}
             {ancestor.scientific_name}
           </span>
-        </Tooltip>
+        </Tooltip>,
       );
     });
   }
@@ -93,7 +93,7 @@ export const LineageList = ({
     lineage.taxon.taxon_rank == "clade" ? "" : lineage.taxon.taxon_rank;
   let css = classnames(
     rankStyle,
-    fullRanks.has(lineage.taxon.taxon_rank) && boldStyle
+    fullRanks.has(lineage.taxon.taxon_rank) && boldStyle,
   );
   let rankDiv = <div className={css}>{rank}</div>;
   lineageDivs.push(
@@ -106,7 +106,7 @@ export const LineageList = ({
     >
       {rankDiv}
       {lineage.taxon.scientific_name}
-    </span>
+    </span>,
   );
 
   return <div style={{ maxWidth: "100%" }}>{lineageDivs}</div>;
@@ -150,5 +150,5 @@ export default compose(
   withTaxonomy,
   dispatchLookup,
   withSearch,
-  withRecord
+  withRecord,
 )(LineagePanel);

--- a/src/genomehubs-ui/src/client/views/components/QueryBuilder.jsx
+++ b/src/genomehubs-ui/src/client/views/components/QueryBuilder.jsx
@@ -57,7 +57,7 @@ const QueryBuilder = ({
   const navigate = useNavigate();
   let ranks = {
     "": "",
-    superkingdom: "superkingdom",
+    domain: "domain",
     kingdom: "kingdom",
     phylum: "phylum",
     class: "class",

--- a/src/genomehubs-ui/src/client/views/components/ResultFilter.jsx
+++ b/src/genomehubs-ui/src/client/views/components/ResultFilter.jsx
@@ -42,7 +42,7 @@ const ResultFilter = ({
   }
   let ranks = {
     "": "",
-    superkingdom: "superkingdom",
+    domain: "domain",
     kingdom: "kingdom",
     phylum: "phylum",
     class: "class",

--- a/src/genomehubs-ui/src/client/views/selectors/types.js
+++ b/src/genomehubs-ui/src/client/views/selectors/types.js
@@ -117,9 +117,9 @@ export const taxonomyRanks = {
     display_name: "Kingdom",
     display_group: "ranks",
   },
-  superkingdom: {
-    name: "superkingdom",
-    display_name: "Superkingdom",
+  domain: {
+    name: "domain",
+    display_name: "Domain",
     display_group: "ranks",
   },
 };
@@ -238,7 +238,7 @@ export const getRankTrie = createSelector(getTypesMap, (types) => {
     "class",
     "order",
     "phylum",
-    "superkingdom",
+    "domain",
   ];
   let otherRanks = [
     "biotype",

--- a/src/genomehubs/lib/version.py
+++ b/src/genomehubs/lib/version.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python3
 """genomehubs version."""
 
-__version__ = "2.10.14"
+__version__ = "2.10.15"

--- a/src/genomehubs/lib/version.py
+++ b/src/genomehubs/lib/version.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python3
 """genomehubs version."""
 
-__version__ = "2.10.13"
+__version__ = "2.10.14"

--- a/src/packaged-ui/package-lock.json
+++ b/src/packaged-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "genomehubs-ui",
-  "version": "2.10.14",
+  "version": "2.10.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "genomehubs-ui",
-      "version": "2.10.14",
+      "version": "2.10.15",
       "license": "MIT",
       "dependencies": {
         "ejs": "^3.1.7",

--- a/src/packaged-ui/package-lock.json
+++ b/src/packaged-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "genomehubs-ui",
-  "version": "2.10.13",
+  "version": "2.10.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "genomehubs-ui",
-      "version": "2.10.13",
+      "version": "2.10.14",
       "license": "MIT",
       "dependencies": {
         "ejs": "^3.1.7",

--- a/src/packaged-ui/package.json
+++ b/src/packaged-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genomehubs-ui",
-  "version": "2.10.13",
+  "version": "2.10.14",
   "repository": "https://github.com/genomehubs/genomehubs",
   "description": "",
   "bin": "src/app.js",

--- a/src/packaged-ui/package.json
+++ b/src/packaged-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genomehubs-ui",
-  "version": "2.10.14",
+  "version": "2.10.15",
   "repository": "https://github.com/genomehubs/genomehubs",
   "description": "",
   "bin": "src/app.js",


### PR DESCRIPTION
## Summary by Sourcery

Bump the release to 2.10.15, modernize CI workflows, add API archive build and publish steps, implement a new taxonomic ranks endpoint, and consolidate 'superkingdom' to 'domain' in code and schemas

New Features:
- Add a GitHub Action job to build and push the genomehubs API archive as a Docker image
- Introduce a new API endpoint (/taxonomicRanks) returning the list of valid taxonomic ranks

Enhancements:
- Replace 'superkingdom' with 'domain' in rank definitions and UI/ API code
- Improve histogram report logic with optional chaining and safer null handling

Build:
- Bump project version from 2.10.13 to 2.10.15 across workflows, package configs, Dockerfiles, and docs

CI:
- Upgrade GitHub Actions workflows to use actions/checkout@v4 and actions/setup-node@v4 with Node 18
- Revise archive packaging workflows: update ARCHIVE_VERSION, rename jobs, adjust environment variables, and artifact steps

Documentation:
- Extend OpenAPI spec with TaxonomicRanks schema and /taxonomicRanks operation